### PR TITLE
enforce UTF-8 gemfile parsing encoding #7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.bundle/
 /.yardoc
-/Gemfile.lock
 /_yardoc/
 /coverage/
 /doc/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,18 @@
 language: ruby
-before_install: gem install bundler -v $BUNDLER_VERSION
+before_install:
+  - find /home/travis/.rvm/rubies -wholename '*default/bundler-*.gemspec' -delete
+  - gem install bundler -v $BUNDLER_VERSION
 install: bundle _${BUNDLER_VERSION}_ install --jobs=3 --retry=3
 script: bundle _${BUNDLER_VERSION}_ exec rake test
 matrix:
   include:
+    - rvm: 2.5
+      env: BUNDLER_VERSION=1.16.1
+    - rvm: 2.4
+      env: BUNDLER_VERSION=1.16.1
     - rvm: 2.2
       env: BUNDLER_VERSION=1.12.1
     - rvm: 2.2
-      env: BUNDLER_VERSION=1.5.3
-    - rvm: 1.9
       env: BUNDLER_VERSION=1.12.1
-    - rvm: 1.9
-      env: BUNDLER_VERSION=1.5.3
+    - rvm: 2.0
+      env: BUNDLER_VERSION=1.12.1

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,10 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in grub.gemspec
+# Specify your gem's dependencies in annotate_gem.gemspec
 gemspec
+
+# Fast debugging with Pry. (https://github.com/deivid-rodriguez/pry-byebug)
+gem "pry-byebug", :platforms => "ruby_22"
 
 # An IRB alternative and runtime developer console (http://pryrepl.org)
 gem "pry"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,37 @@
+PATH
+  remote: .
+  specs:
+    annotate_gem (0.0.11)
+      bundler (~> 1.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    byebug (10.0.2)
+    coderay (1.1.2)
+    metaclass (0.0.4)
+    method_source (0.9.0)
+    minitest (5.11.3)
+    mocha (1.5.0)
+      metaclass (~> 0.0.1)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-byebug (3.6.0)
+      byebug (~> 10.0)
+      pry (~> 0.10)
+    rake (10.5.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  annotate_gem!
+  minitest (~> 5.0)
+  mocha (~> 1.1)
+  pry
+  pry-byebug
+  rake (~> 10.0)
+
+BUNDLED WITH
+   1.16.1

--- a/README.md
+++ b/README.md
@@ -47,7 +47,22 @@ source 'https://rubygems.org'
 gem "pry"
 ```
 
-`annotate-gem` has several options and you can see them via `annotate-gem -h`. `annotate-gem` also works with specifying a single gem name:
+`annotate-gem` has several options:
+
+```
+$ annotate_gem --help
+  Add comments to your Gemfile with each dependency's description.
+        Usage: annotate_gem [options]
+               annotate_gem [gem name]
+        --website-only               Only output the website
+        --description-only           Only output the description
+        --new-comments-only          Only add a comment to gemfile if there isn't a comment already (for non-inline comments)
+        --inline                     Inline the comment
+    -h, --help                       Show this message
+    -v, --version                    Show version
+```
+
+`annotate-gem` also works with specifying a single gem name:
 
 ```
 $ annotate-gem aasm

--- a/lib/annotate_gem/gemfile.rb
+++ b/lib/annotate_gem/gemfile.rb
@@ -13,9 +13,10 @@ module AnnotateGem
     end
 
     def parse
-      self.source = File.readlines(gemfile_path)
+      self.source = File.readlines(gemfile_path, :encoding => 'UTF-8')
       source.each_with_index do |line, i|
-        if match = GEM_LINE_REGEX.match(line)
+        match = GEM_LINE_REGEX.match(line)
+        if match
           prev_line = source[i - 1] if i > 0
           prev_line_comment = prev_line if is_line_a_comment?(prev_line)
           self.gem_lines << GemLine.new(

--- a/test/annotate_gem/cli_test.rb
+++ b/test/annotate_gem/cli_test.rb
@@ -6,7 +6,7 @@ class AnnotateGem::CLITest < Minitest::Test
 
   def test_run_for_gemfile
     with_gemfile(File.read(gemfile_path)) do |path|
-      Bundler.expects(:default_gemfile).returns(path)
+      Bundler.expects(:default_gemfile).returns(Pathname.new(path)).at_least_once
       out, _ = capture_io do
         AnnotateGem::CLI.new.run_for_gemfile
       end

--- a/test/annotate_gem/gemfile_test.rb
+++ b/test/annotate_gem/gemfile_test.rb
@@ -36,6 +36,16 @@ class AnnotateGem::GemfileTest < Minitest::Test
     assert_equal 2, gemfile.gem_lines.length
   end
 
+  def test_parses_non_ascii_symbols
+    gemfile_content=unindent(<<-GEMFILE)
+      # Non ASCII 鋸 набор סמלים
+    GEMFILE
+
+    gemfile = gemfile_for(gemfile_content.force_encoding('ASCII'))
+
+    assert_equal 0, gemfile.gem_lines.length
+  end
+
   def test_write_comments
     with_gemfile("gem 'rails'") do |path|
       gemfile = AnnotateGem::Gemfile.new(path)

--- a/test/fixtures/Gemfile
+++ b/test/fixtures/Gemfile
@@ -23,9 +23,20 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
+# Non ASCII 鋸 набор סמלים
+
+gem 'nokogiri', '1.8.2'
+
 group :development, :test do
   gem 'byebug'
   gem 'web-console', '~> 2.0'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
+end
+
+# test ruby code in Gemfile
+if ENV['wisper']
+  gem 'wisper-activejob',
+    git: 'https://github.com/cambridgebrainsciences/wisper-activejob.git',
+    branch: 'rails5'
 end

--- a/test/fixtures/Gemfile_annotated
+++ b/test/fixtures/Gemfile_annotated
@@ -13,14 +13,14 @@ gem 'coffee-rails', '~> 4.1.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby
 
-# Use jQuery with Rails 4+ (http://rubygems.org/gems/jquery-rails)
+# Use jQuery with Rails 4+ (https://github.com/rails/jquery-rails)
 gem 'jquery-rails'
-# Turbolinks makes navigating your web application faster (https://github.com/turbolinks/turbolinks-rails)
+# Turbolinks makes navigating your web application faster (https://github.com/turbolinks/turbolinks)
 gem 'turbolinks'
 # Create JSON structures via a Builder-style DSL (https://github.com/rails/jbuilder)
 gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.
-# rdoc html with javascript search index. (http://github.com/voloko/sdoc)
+# rdoc html with javascript search index. (https://github.com/zzak/sdoc)
 gem 'sdoc', '~> 0.4.0', group: :doc
 
 # Use ActiveModel has_secure_password
@@ -32,12 +32,25 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
+# Non ASCII 鋸 набор סמלים
+
+# Nokogiri (鋸) is an HTML, XML, SAX, and Reader parser (http://nokogiri.org)
+gem 'nokogiri', '1.8.2'
+
 group :development, :test do
-  # Ruby 2.0 fast debugger - base + CLI (http://github.com/deivid-rodriguez/byebug)
+  # Ruby fast debugger - base + CLI (http://github.com/deivid-rodriguez/byebug)
   gem 'byebug'
   # A debugging tool for your Ruby on Rails applications. (https://github.com/rails/web-console)
   gem 'web-console', '~> 2.0'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   # Rails application preloader (https://github.com/rails/spring)
   gem 'spring'
+end
+
+# test ruby code in Gemfile
+if ENV['wisper']
+  # Provides Wisper with asynchronous event publishing using ActiveJob (https://github.com/krisleech/wisper-activejob)
+  gem 'wisper-activejob',
+    git: 'https://github.com/cambridgebrainsciences/wisper-activejob.git',
+    branch: 'rails5'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 require "minitest/autorun"
-require "mocha/mini_test"
+require "mocha/minitest"
 require "annotate_gem"
+require "pry"
 
 module TestHelpers
 


### PR DESCRIPTION
This PR fixes non-ascii symbol parsing in Gemfile. Also, had to fix travis build by upgrading supported ruby versions and some tricks with bundler installation. Fixes #7 

