### PR TITLE
Supported when the latest version is only on another platform

### DIFF
--- a/lib/annotate_gem/spec_finder.rb
+++ b/lib/annotate_gem/spec_finder.rb
@@ -29,12 +29,17 @@ module AnnotateGem
         gem_versions = versions.select { |v| v.first == gem_line.name }
         next if gem_versions.empty? # couldn't find version on RubyGems so go to next one
         version = find_latest_version(gem_versions)
-        gem_line.spec = fetcher.fetch_spec([gem_line.name, version])
+        platform = find_latest_version_platform(gem_versions)
+        gem_line.spec = fetcher.fetch_spec([gem_line.name, version, platform])
       end
     end
 
     def find_latest_version(versions)
-       versions.sort_by { |v| v[1] }.last[1]
+      versions.sort_by { |v| v[1] }.last[1]
+    end
+
+    def find_latest_version_platform(versions)
+      versions.sort_by { |v| v[1] }.last[2]
     end
 
     private

--- a/test/annotate_gem/spec_finder_test.rb
+++ b/test/annotate_gem/spec_finder_test.rb
@@ -36,12 +36,12 @@ class AnnotateGem::SpecFinderTest < Minitest::Test
     gem_line_2.expects(:spec=).with(spec_2)
 
     AnnotateGem::SpecFinder.expects(:get_versions).with(instance_of(Bundler::Fetcher), ["1", "2"]).returns([
-      ["1", Gem::Version.new("1")],
-      ["2", Gem::Version.new("1")],
+      ["1", Gem::Version.new("1"), "ruby"],
+      ["2", Gem::Version.new("1"), "ruby"],
     ])
     AnnotateGem::SpecFinder.expects(:find_latest_version).returns(Gem::Version.new("1")).twice
-    Bundler::Fetcher.any_instance.expects(:fetch_spec).with(["1", Gem::Version.new("1")]).returns(spec_1)
-    Bundler::Fetcher.any_instance.expects(:fetch_spec).with(["2", Gem::Version.new("1")]).returns(spec_2)
+    Bundler::Fetcher.any_instance.expects(:fetch_spec).with(["1", Gem::Version.new("1"), "ruby"]).returns(spec_1)
+    Bundler::Fetcher.any_instance.expects(:fetch_spec).with(["2", Gem::Version.new("1"), "ruby"]).returns(spec_2)
     yielded_values = []
     AnnotateGem::SpecFinder.fetch_specs_for([gem_line_1, gem_line_2]) do |*args|
       yielded_values << args
@@ -71,5 +71,13 @@ class AnnotateGem::SpecFinderTest < Minitest::Test
       ["rails", Gem::Version.new("4")]
     ]
     assert_equal Gem::Version.new("4"), AnnotateGem::SpecFinder.find_latest_version(versions)
+  end
+
+  def test_find_latest_version_platform
+    versions = [
+      ["rails", Gem::Version.new("2.3.5"), "ruby"],
+      ["rails", Gem::Version.new("4"), "ruby"]
+    ]
+    assert_equal "ruby", AnnotateGem::SpecFinder.find_latest_version_platform(versions)
   end
 end


### PR DESCRIPTION
When try fetch gem metadata that  latest version is only on another platform(like activerecord-jdbcsqlite3-adapter), got error.

```bash
$ bin/annotate_gem activerecord-jdbcsqlite3-adapter
Fetching gem metadata.....
Traceback (most recent call last):
        8: from bin/annotate_gem:8:in `<main>'
        7: from /home/vagrant/oss/annotate_gem/lib/annotate_gem/cli.rb:10:in `run'
        6: from /home/vagrant/oss/annotate_gem/lib/annotate_gem/cli.rb:26:in `run_for_gem'
        5: from /home/vagrant/oss/annotate_gem/lib/annotate_gem/spec_finder.rb:9:in `find_specs_for'
        4: from /home/vagrant/oss/annotate_gem/lib/annotate_gem/spec_finder.rb:26:in `fetch_specs_for'
        3: from /home/vagrant/oss/annotate_gem/lib/annotate_gem/spec_finder.rb:26:in `each'
        2: from /home/vagrant/oss/annotate_gem/lib/annotate_gem/spec_finder.rb:32:in `block in fetch_specs_for'
        1: from /home/vagrant/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/bundler-1.16.2/lib/bundler/fetcher.rb:103:in `fetch_spec'
/home/vagrant/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/bundler-1.16.2/lib/bundler/fetcher/downloader.rb:37:in `fetch': Net::HTTPForbidden: <?xml version="1.0" encoding="UTF-8"?> (Bundler::HTTPError)
<Error><Code>AccessDenied</Code><Message>Access Denied</Message><RequestId>32A6D5763BC76CFD</RequestId><HostId>KqPZr9PRJ1FF7gWB6zDPt6gRHsfYMdLLZL2Dt2wCXdywhv2Ltxs/Vv17DKJ9riQAaL1qMouuW34=</HostId></Error>
```

Because uri trying to fetch bundler is https://rubygems.org/quick/Marshal.4.8/activerecord-jdbcsqlite3-adapter-51.1.gemspec.rz , but that uri is invalid.
It is correctly  https://rubygems.org/quick/Marshal.4.8/activerecord-jdbcsqlite3-adapter-51.1-java.gemspec.rz .
Fix to correct fetch even if the latest version is only on another platform.
